### PR TITLE
add missing GMP library

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '5'
+gmp:
+- '6'
 ipopt:
 - 3.14.16
 libblas:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -195,7 +195,7 @@ outputs:
       - "{{ install_prefix }}/include/graph"
     test:
       commands:
-        - gcg --version   # [unix]
+        - gcg --version
         - test -d "${PREFIX}/lib/cmake/gcg"  # [unix]
         - test -d "${PREFIX}/include/gcg"    # [unix]
         - test -d "${PREFIX}/include/graph"  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - boost-cpp 1.72  # [win]
     - libboost-devel  # [unix]
     - mpfr
-    - gmp             # [unix]
+    - gmp
     - cliquer         # [unix]
     - pcre2           # [win]
 
@@ -58,7 +58,7 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - zlib
-        - gmp             # [unix]
+        - gmp
         - mpfr
         - libboost-headers
         - libblas
@@ -90,7 +90,7 @@ outputs:
         - zlib
         - ipopt
         - cppad
-        - gmp   # [unix]
+        - gmp
         - mpfr
         # Papilo statically linked
         # Papilo statically linked but needs direct dependency from used shared libs.
@@ -134,7 +134,7 @@ outputs:
         - {{ stdlib("c") }}
       host:
         - zlib
-        - gmp             # [unix]
+        - gmp
         - mpfr
         - boost-cpp 1.72  # [win]
         - libboost-devel  # [unix]
@@ -178,7 +178,7 @@ outputs:
         - {{ stdlib("c") }}
         - {{ compiler('cxx') }}
       host:
-        - gmp       # [unix]
+        - gmp
         - cliquer   # [unix]
         - gnuplot   # [unix]
         - {{ pin_subpackage('scip', exact=True) }}
@@ -214,7 +214,7 @@ outputs:
         - winflexbison  # [win]
       host:
         - zlib
-        - gmp    # [unix]
+        - gmp
         - mpfr
         - pcre2  # [win]
     files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     folder: scipoptsuite
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This seems to fix the issue raised in https://github.com/conda-forge/scipoptsuite-feedstock/pull/73#issuecomment-2343673508 about the GCG executable not executing in the Windows builds.

The hint from #74, and the log message
```
2024-09-30T11:07:21.4135200Z WARNING (scip,Library/bin/libscip.dll): Needed DSO Library/bin/libgmp-10.dll found in ['conda-forge/win-64::gmp==6.3.0=hfeafd45_2']
2024-09-30T11:07:21.4138217Z WARNING (scip,Library/bin/libscip.dll): .. but ['conda-forge/win-64::gmp==6.3.0=hfeafd45_2'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```
indicate that the GMP library was missing. So this PR removes the `# [unix]` from all mentions of `gmp` in `recipe/meta.yaml` and reenables the test whether the gcg.exe can be executed.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

