### PR TITLE
SCIP Optimization Suite 9.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/scipoptsuite-fe
 
 Home: https://scipopt.org/
 
-Package license: Apache 2.0 AND ZIB-Academic AND LGPL-3.0-or-later
+Package license: Apache-2.0 AND LGPL-3.0-or-later
 
 Summary: Mixed Integer Programming (MIP) solver and Branch-and-Cut-and-Price Framework
 

--- a/recipe/0002-papilo-copy-findgmp.patch
+++ b/recipe/0002-papilo-copy-findgmp.patch
@@ -1,0 +1,10 @@
+--- a/papilo/papilo-config.cmake.in
++++ b/papilo/papilo-config.cmake.in
+@@ -21,6 +21,7 @@ endif()
+ set(PAPILO_HAVE_GMP @PAPILO_HAVE_GMP@)
+ if(PAPILO_HAVE_GMP AND PAPILO_FOUND)
+     if(NOT GMP_FOUND)
++        list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} @CMAKE_SOURCE_DIR@/cmake/Modules)
+         find_dependency(GMP)
+     endif()
+     if(NOT GMP_FOUND)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
     patches:
       # header-only does not work with current boost due to https://github.com/boostorg/serialization/issues/232
       - 0001-disable-boost-no-lib.patch  # [win]
+      - 0002-papilo-copy-findgmp.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,10 +72,17 @@ outputs:
     files:
       - "{{ install_prefix }}/lib/cmake/papilo/"
       - "{{ install_prefix }}/bin/papilo*"
+      - "{{ install_prefix }}/include/papilo/"
       # Vendored libraries
       - "{{ install_prefix }}/lib/libclusol*"
       - "{{ install_prefix }}/lib/libpapilo-core*"
-      - "{{ install_prefix }}/include/papilo/"
+    test:
+      commands:
+        - papilo
+        - test -d "${PREFIX}/lib/cmake/papilo"  # [unix]
+        - test -d "${PREFIX}/include/papilo"    # [unix]
+        - if exist %PREFIX%\\Library\\lib\\cmake\\papilo (exit 0) else (exit 1)  # [win]
+        - if exist %PREFIX%\\Library\\include\\papilo (exit 0) else (exit 1)     # [win]
 
   - name: scip
     version: {{ scip_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -236,7 +236,7 @@ outputs:
 
 about:
   home: https://scipopt.org/
-  license: Apache 2.0 AND ZIB-Academic AND LGPL-3.0-or-later
+  license: Apache 2.0 AND LGPL-3.0-or-later
   license_file:
     - scipoptsuite/papilo/COPYING
     - scipoptsuite/papilo/src/papilo/external/lusol/LICENSE.md

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -237,7 +237,7 @@ outputs:
 
 about:
   home: https://scipopt.org/
-  license: Apache 2.0 AND LGPL-3.0-or-later
+  license: Apache-2.0 AND LGPL-3.0-or-later
   license_file:
     - scipoptsuite/papilo/COPYING
     - scipoptsuite/papilo/src/papilo/external/lusol/LICENSE.md

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,15 +62,16 @@ outputs:
         - zlib
         - gmp
         - mpfr
-        - libboost-headers  # [unix]
-        - libboost-devel    # [win]
+        # to run the papilo exe, boost libs are needed on unix as well
+        - libboost-devel
         - libblas
       run:
         - tbb-devel
+        # papilo executable depends on scip library
+        - {{ pin_subpackage('scip') }}
     files:
       - "{{ install_prefix }}/lib/cmake/papilo/"
-      # Executable is not installed by Papilo's CMake
-      # - "{{ install_prefix }}/bin/papilo*"
+      - "{{ install_prefix }}/bin/papilo*"
       # Vendored libraries
       - "{{ install_prefix }}/lib/libclusol*"
       - "{{ install_prefix }}/lib/libpapilo-core*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 # TODO check these versions have not changed
-{% set scip_version = "9.1.1" %}
-{% set papilo_version = "2.3.1" %}
-{% set soplex_version = "7.1.1" %}
-{% set gcg_version = "3.6.3" %}
-{% set zimpl_version = "3.6.1" %}
+{% set scip_version = "9.2.0" %}
+{% set papilo_version = "2.4.0" %}
+{% set soplex_version = "7.1.2" %}
+{% set gcg_version = "3.7.0" %}
+{% set zimpl_version = "3.6.2" %}
 # For dispatching between Unix and Windows
 {% set install_prefix = "." %}        # [unix]
 {% set install_prefix = "Library" %}  # [win]
@@ -15,14 +15,14 @@ package:
 
 source:
   - url: https://scipopt.org/download/release/scipoptsuite-{{ scip_version }}.tgz
-    sha256: 331d9f30367add81518d95d353085dd051f3caf80f167548f8dd62d2ed959a6c
+    sha256: a174cc58592d245c74c9c95c1d4819750d7ba2d467b4baae616a5aa336aac8d0
     folder: scipoptsuite
     patches:
       # header-only does not work with current boost due to https://github.com/boostorg/serialization/issues/232
       - 0001-disable-boost-no-lib.patch  # [win]
 
 build:
-  number: 3
+  number: 0
 
 requirements:
   build:

--- a/recipe/run_soplex_test.bat
+++ b/recipe/run_soplex_test.bat
@@ -3,6 +3,7 @@ echo project(SoplexExample) >> CMakeLists.txt
 echo find_package(SOPLEX REQUIRED) >> CMakeLists.txt
 echo # Soplex needs papilo but does not add it >> CMakeLists.txt
 echo find_package(papilo REQUIRED) >> CMakeLists.txt
+echo set(CMAKE_CXX_STANDARD 14) >> CMakeLists.txt
 echo add_executable(example scipoptsuite/soplex/src/example.cpp) >> CMakeLists.txt
 echo target_link_libraries(example PUBLIC libsoplex papilo) >> CMakeLists.txt
 echo target_link_libraries(example PUBLIC libsoplex) >> CMakeLists.txt

--- a/recipe/run_soplex_test.sh
+++ b/recipe/run_soplex_test.sh
@@ -10,6 +10,7 @@ project(SoplexExample)
 find_package(SOPLEX REQUIRED)
 # Soplex needs papilo but does not add it
 find_package(papilo REQUIRED)
+set(CMAKE_CXX_STANDARD 14)
 add_executable(example scipoptsuite/soplex/src/example.cpp)
 target_link_libraries(example PUBLIC libsoplex papilo)
 EOF


### PR DESCRIPTION
- Update to SCIP Optimization Suite 9.2.0.
- There is an issue with papilos cmake config (FindGMP.cmake not found in some environments), so a patch is added to work around this.
- Fixed license info: ZIB Academic license is not longer used; fix Apache license identifier
- Include papilo executable into papilo package, which comes with dependencies on scip and boost.
- Add minimal test for papilo package.
- SoPlex headers are C++14, so require that for the SoPlex example as well.

The conda-forge linter is now happy. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
