### PR TITLE
see if we can reenable LUSOL for macOS/x86_64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,11 +10,6 @@ if [[ "${target_platform}" == linux-* ]] ; then
     export LDFLAGS="-lrt ${LDFLAGS}"
 fi
 
-# conda's build of gfortran does not work anymore, it fails with clang: error: no input files
-if [ "${target_platform}" = osx-64 ] ; then
-    CMAKE_ARGS="$CMAKE_ARGS -DLUSOL=OFF"
-fi
-
 cmake -B scipoptsuite-build -S "${SRC_DIR}/scipoptsuite" \
       -G Ninja \
       -D CMAKE_BUILD_TYPE=Release \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
       - 0001-disable-boost-no-lib.patch  # [win]
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
This reverts commit 11e99dcc7099ad1b7abb20dc3cca3336102413cf.

The build image for macOS changed from macOS 13 to 15 with 0a00be1cc50109a8ad20665f3f15b3b4cb94552a. Try whether this fixes the issue on the macOS/x86_64 build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
